### PR TITLE
How to comment out parts of LaTeX by modifying tmLanguage.json of VDM.

### DIFF
--- a/vdmpp/syntaxes/vdmpp.tmLanguage.json
+++ b/vdmpp/syntaxes/vdmpp.tmLanguage.json
@@ -15,12 +15,22 @@
 	"scopeName": "source.vdmpp",
 	"repository": {
 		"vdm-in-latex": {
-			"begin": "(\\\\begin{.*})",
-			"end": "(?=\\\\end{.*})",
-			"name": "meta.latex",
+			"patterns": [
+				{
+					"include": "#inside-latex"
+				},
+				{
+					"include": "#outside-latex"
+				}
+			]
+		},
+		"inside-latex": {
+			"begin": "(\\\\begin\\{.*\\})",
+			"end": "(?=\\\\end\\{.*\\})",
+			"name": "meta.inside.latex",
 			"beginCaptures": {
 				"1": {
-					"name": "comment.line"
+					"name": "keyword.other"
 				}
 			},
 			"patterns": [
@@ -29,10 +39,21 @@
 				}
 			]
 		},
-		"other-latex": {
-			"begin": "[\\S\\s]*",
-			"end": "(?=\\\\begin{.*})",
-			"name": "comment.line"
+		"outside-latex": {
+			"begin": "(\\\\end\\{.*\\})",
+			"end": "(?=\\\\begin\\{.*\\})",
+			"name": "meta.outside.latex",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other"
+				}
+			},
+			"patterns": [
+				{
+					"name": "comment.block",
+					"match": "\\S+"
+				}
+			]
 		}
 	}
 }

--- a/vdmpp/syntaxes/vdmpp.tmLanguage.json
+++ b/vdmpp/syntaxes/vdmpp.tmLanguage.json
@@ -3,8 +3,36 @@
 	"name": "VDM",
 	"patterns": [
 		{
+			"include": "#vdm-in-latex"
+		},
+		{
+			"include": "#other-latex"
+		},
+		{
 			"include": "source.vdm"
 		}
 	],
-	"scopeName": "source.vdmpp"
+	"scopeName": "source.vdmpp",
+	"repository": {
+		"vdm-in-latex": {
+			"begin": "(\\\\begin{.*})",
+			"end": "(?=\\\\end{.*})",
+			"name": "meta.latex",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.line"
+				}
+			},
+			"patterns": [
+				{
+					"include": "source.vdm"
+				}
+			]
+		},
+		"other-latex": {
+			"begin": "[\\S\\s]*",
+			"end": "(?=\\\\begin{.*})",
+			"name": "comment.line"
+		}
+	}
 }


### PR DESCRIPTION
This pull request is an example of one.

It can comment out the LaTeX parts with the following rules:
- The part enclosed in the `\begin{*}` and `\end{*}` is defined as a VDM.
- The part enclosed in the `\end{*}` and the `\begin{*}` is defined as a comment.

But, not commenting out from the beginning to the first begin. Because syntax highlighting in VDM without LaTeX is broken. I have tried various methods, but no good solution is obtained.

This method does not affect the VDM, which does not contain `\begin{*}` or `\end{*}`.

<img width="543" alt="スクリーンショット 2020-11-29 19 50 57" src="https://user-images.githubusercontent.com/20027695/100539805-35825700-327c-11eb-83bb-cbaac189a3f8.png">
