### PR TITLE
How to embed VDM in LaTeX.

### DIFF
--- a/vdmpp/package.json
+++ b/vdmpp/package.json
@@ -320,6 +320,19 @@
           ".vdmpp"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "latex",
+        "aliases": [
+          "LaTeX",
+          "latex"
+        ],
+        "extensions": [
+          ".tex",
+          ".ltx",
+          ".ctx"
+        ],
+        "configuration": "./syntax/syntax.json"
       }
     ],
     "grammars": [
@@ -347,6 +360,29 @@
       {
         "scopeName": "source.vdm.statements",
         "path": "./syntaxes/vdm.statements.tmLanguage.json"
+      },
+      {
+        "language": "latex",
+        "scopeName": "text.tex.latex",
+        "path": "./syntaxes/latex.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.asymptote": "asymptote",
+          "source.cpp": "cpp_embedded_latex",
+          "source.css": "css",
+          "source.dot": "dot",
+          "source.gnuplot": "gnuplot",
+          "text.html": "html",
+          "source.java": "java",
+          "source.js": "javascript",
+          "source.lua": "lua",
+          "source.python": "python",
+          "source.ruby": "ruby",
+          "source.scala": "scala",
+          "source.ts": "typescript",
+          "text.xml": "xml",
+          "source.yaml": "yaml",
+          "source.vdmpp": "vdmpp"
+        }
       }
     ],
     "debuggers": [

--- a/vdmpp/package.json
+++ b/vdmpp/package.json
@@ -332,7 +332,7 @@
           ".ltx",
           ".ctx"
         ],
-        "configuration": "./syntax/syntax.json"
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [

--- a/vdmpp/syntaxes/latex.tmLanguage.json
+++ b/vdmpp/syntaxes/latex.tmLanguage.json
@@ -1,0 +1,1676 @@
+{
+    "fileTypes": [
+      "tex"
+    ],
+    "firstLineMatch": "^\\\\documentclass(\\[.*\\])?\\{.*\\}",
+    "keyEquivalent": "^~L",
+    "name": "LaTeX",
+    "patterns": [
+      {
+        "begin": "(\\\\begin\\{vdm_al\\})",
+        "contentName": "source.vdmpp",
+        "patterns": [
+            {
+            "include": "source.vdmpp"
+            }
+        ],
+        "end": "(\\\\end\\{vdm_al\\})"
+      },
+      {
+        "comment": "This scope identifies partially typed commands such as `\\tab`. We use this to trigger “Command Completion” only when it makes sense.",
+        "match": "(?<=\\\\[\\w@]|\\\\[\\w@]{2}|\\\\[\\w@]{3}|\\\\[\\w@]{4}|\\\\[\\w@]{5}|\\\\[\\w@]{6})\\s",
+        "name": "meta.space-after-command.latex"
+      },
+      {
+        "begin": "((\\\\)(?:usepackage|documentclass))((?:\\[[^\\[]*?\\])*)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.control.preamble.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "contentName": "support.class.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.preamble.latex",
+        "patterns": [
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)(?:include|input))(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.control.include.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.include.latex",
+        "patterns": [
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)((?:sub){0,2}section|(?:sub)?paragraph|chapter|part|addpart|addchap|addsec|minisec|frametitle)(?:\\*)?)((?:\\[[^\\[]*?\\]){0,2})(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "support.function.section.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "4": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "comment": "this works OK with all kinds of crazy stuff as long as section is one line",
+        "contentName": "entity.name.section.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.function.section.$3.latex",
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(^\\s*)?(?=\\\\begin\\{(lstlisting|minted|pyglist)\\})",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.whitespace.embedded.leading.latex"
+          }
+        },
+        "end": "(?!\\G)(\\s*$\\n?)?",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.whitespace.embedded.trailing.latex"
+          }
+        },
+        "patterns": [
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(?:cpp|c)\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.cpp.embedded.latex",
+            "patterns": [
+              {
+                "include": "source.cpp.embedded.latex"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{css\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.css",
+            "patterns": [
+              {
+                "include": "source.css"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{html\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "text.html",
+            "patterns": [
+              {
+                "include": "text.html.basic"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{java\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.java",
+            "patterns": [
+              {
+                "include": "source.java"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(?:js|javascript)\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.js",
+            "patterns": [
+              {
+                "include": "source.js"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(?:ts|typescript)\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.ts",
+            "patterns": [
+              {
+                "include": "source.ts"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{lua\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.lua",
+            "patterns": [
+              {
+                "include": "source.lua"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(?:python|py)\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.python",
+            "patterns": [
+              {
+                "include": "source.python"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{(ruby)\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.ruby",
+            "patterns": [
+              {
+                "include": "source.ruby"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{xml\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "text.xml",
+            "patterns": [
+              {
+                "include": "text.xml"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{minted\\}(?:\\[.*\\])?\\{yaml\\})",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "source.yaml",
+            "patterns": [
+              {
+                "include": "source.yaml"
+              }
+            ],
+            "end": "(\\\\end\\{minted\\})"
+          },
+          {
+            "begin": "(\\\\begin\\{(?:lstlisting|minted|pyglist)\\}(?:\\[.*\\])?)",
+            "captures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#minted-env"
+                  }
+                ]
+              }
+            },
+            "contentName": "meta.function.embedded.latex",
+            "end": "(\\\\end\\{(?:lstlisting|minted|pyglist)\\})",
+            "name": "meta.embedded.block.generic"
+          }
+        ]
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{(cppcode(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.cpp.embedded.latex",
+        "patterns": [
+          {
+            "include": "source.cpp.embedded.latex"
+          },
+          {
+            "include": "source.cpp"
+          }
+        ],
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{(hscode(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.haskell",
+        "patterns": [
+          {
+            "include": "source.haskell"
+          }
+        ],
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{(luacode(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.lua",
+        "patterns": [
+          {
+            "include": "source.lua"
+          }
+        ],
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{((?:pycode|sageblock|sagesilent|sageverbatim|sageexample|sagecommandline)(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.python",
+        "patterns": [
+          {
+            "include": "source.python"
+          }
+        ],
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{(scalacode(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.scala",
+        "patterns": [
+          {
+            "include": "source.scala"
+          }
+        ],
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{([a-z]*code(?:\\*)?)\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "end": "(\\\\end\\{\\2\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{asy\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.asymptote",
+        "patterns": [
+          {
+            "include": "source.asymptote"
+          }
+        ],
+        "end": "(\\\\end\\{asy\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{dot2tex\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.dot",
+        "patterns": [
+          {
+            "include": "source.dot"
+          }
+        ],
+        "end": "(\\\\end\\{dot2tex\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((?:\\s*)\\\\begin\\{gnuplot\\}(?:\\[.*\\])?)",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#code-env"
+              }
+            ]
+          }
+        },
+        "contentName": "source.gnuplot",
+        "patterns": [
+          {
+            "include": "source.gnuplot"
+          }
+        ],
+        "end": "(\\\\end\\{gnuplot\\}(?:\\s*\\n)?)"
+      },
+      {
+        "begin": "((\\\\)addplot)(?:\\+?)((?:\\[[^\\[]*\\]))*\\s*(gnuplot)\\s*((?:\\[[^\\[]*\\]))*\\s*(\\{)",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "6": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "patterns": [
+          {
+            "begin": "%",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.definition.comment.latex"
+              }
+            },
+            "end": "$\\n?",
+            "name": "comment.line.percentage.latex"
+          },
+          {
+            "include": "source.gnuplot"
+          }
+        ],
+        "end": "\\s*(\\};)"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:fboxv|boxedv|V|v)erbatim\\*?)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "markup.raw.verbatim.latex",
+        "end": "((\\\\)end)(\\{)(\\4)(\\})",
+        "name": "meta.function.verbatim.latex"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(VerbatimOut)(\\})(\\{)([^\\}]*)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "7": {
+            "name": "support.class.latex"
+          },
+          "8": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "markup.raw.verbatim.latex",
+        "end": "((\\\\)end)(\\{)(\\VerbatimOut)(\\})",
+        "name": "meta.function.verbatim.latex"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(alltt)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "markup.raw.verbatim.latex",
+        "end": "((\\\\)end)(\\{)(alltt)(\\})",
+        "name": "meta.function.alltt.latex",
+        "patterns": [
+          {
+            "captures": {
+              "1": {
+                "name": "punctuation.definition.function.latex"
+              }
+            },
+            "match": "(\\\\)[A-Za-z]+",
+            "name": "support.function.general.latex"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:C|c)omment)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "punctuation.definition.comment.latex",
+        "end": "((\\\\)end)(\\{)(\\4)(\\})",
+        "name": "meta.function.verbatim.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.url.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "markup.underline.link.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "match": "(?:\\s*)((\\\\)(?:url|href))(\\{)([^}]*)(\\})",
+        "name": "meta.function.link.url.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "comment": "These two patterns match the \\begin{document} and \\end{document} commands, so that the environment matching pattern following them will ignore those commands.",
+        "match": "(?:\\s*)((\\\\)begin)(\\{)(document)(\\})",
+        "name": "meta.function.begin-document.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "match": "(?:\\s*)((\\\\)end)(\\{)(document)(\\})",
+        "name": "meta.function.end-document.latex"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)((?:align|equation|(?:IEEE)?eqnarray|multline|aligned|alignat|split|gather|gathered|cases|displaymath|[a-zA-Z]*matrix|(?:(?:arg)?(?:mini|maxi)))(?:\\*|!)?)(\\})(\\s*\\n)?",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "meta.math.block.latex support.class.math.block.environment.latex",
+        "end": "(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.math.latex",
+        "patterns": [
+          {
+            "match": "(?<!\\\\)&",
+            "name": "keyword.control.equation.align.latex"
+          },
+          {
+            "match": "\\\\\\\\",
+            "name": "keyword.control.equation.newline.latex"
+          },
+          {
+            "include": "#definition-label"
+          },
+          {
+            "include": "text.tex#math"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(array|tabular[xy*]?|xltabular|longtable)(\\})(\\s*\\n)?",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "contentName": "meta.data.environment.tabular.latex",
+        "end": "(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.tabular.latex",
+        "patterns": [
+          {
+            "match": "(?<!\\\\)&",
+            "name": "keyword.control.table.cell.latex"
+          },
+          {
+            "match": "\\\\\\\\",
+            "name": "keyword.control.table.newline.latex"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(itemize|enumerate|description|list)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.list.latex",
+        "patterns": [
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(tikzpicture)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "end": "((\\\\)end)(\\{)(tikzpicture)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.latex.tikz",
+        "patterns": [
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(frame)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "end": "((\\\\)end)(\\{)(frame)(\\})",
+        "name": "meta.function.environment.frame.latex",
+        "patterns": [
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(mpost[*]?)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.latex.mpost"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(\\w+[*]?)(\\})",
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
+        "name": "meta.function.environment.general.latex",
+        "patterns": [
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "storage.type.function.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.begin.latex"
+          },
+          "4": {
+            "name": "support.function.general.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.end.latex"
+          }
+        },
+        "match": "((\\\\)(?:newcommand|renewcommand|(?:re)?newrobustcmd|DeclareRobustCommand))\\*?({)((\\\\)[^}]*)(})"
+      },
+      {
+        "begin": "((\\\\)marginpar)((?:\\[[^\\[]*?\\])*)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "support.function.marginpar.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.marginpar.begin.latex"
+          }
+        },
+        "contentName": "meta.paragraph.margin.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.marginpar.end.latex"
+          }
+        },
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)footnote)((?:\\[[^\\[]*?\\])*)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "support.function.footnote.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.footnote.begin.latex"
+          }
+        },
+        "contentName": "entity.name.footnote.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.footnote.end.latex"
+          }
+        },
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)emph)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "support.function.emph.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.emph.begin.latex"
+          }
+        },
+        "contentName": "markup.italic.emph.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.emph.end.latex"
+          }
+        },
+        "name": "meta.function.emph.latex",
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)textit)(\\{)",
+        "captures": {
+          "1": {
+            "name": "support.function.textit.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.textit.begin.latex"
+          }
+        },
+        "comment": "We put the keyword in a capture and name this capture, so that disabling spell checking for “keyword” won't be inherited by the argument to \\textit{...}.\n\nPut specific matches for particular LaTeX keyword.functions before the last two more general functions",
+        "contentName": "markup.italic.textit.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.textit.end.latex"
+          }
+        },
+        "name": "meta.function.textit.latex",
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)textbf)(\\{)",
+        "captures": {
+          "1": {
+            "name": "support.function.textbf.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.textbf.begin.latex"
+          }
+        },
+        "contentName": "markup.bold.textbf.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.textbf.end.latex"
+          }
+        },
+        "name": "meta.function.textbf.latex",
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)texttt)(\\{)",
+        "captures": {
+          "1": {
+            "name": "support.function.texttt.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.texttt.begin.latex"
+          }
+        },
+        "contentName": "markup.raw.texttt.latex",
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.texttt.end.latex"
+          }
+        },
+        "name": "meta.function.texttt.latex",
+        "patterns": [
+          {
+            "include": "text.tex#braces"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "captures": {
+          "0": {
+            "name": "keyword.other.item.latex"
+          },
+          "1": {
+            "name": "punctuation.definition.keyword.latex"
+          }
+        },
+        "match": "(\\\\)item\\b",
+        "name": "meta.scope.item.latex"
+      },
+      {
+        "begin": "((\\\\)(?:[aA]uto|foot|full|no|short|[tT]ext|[pP]aren|[sS]mart)?[cC]ite(?:al)?(?:p|s|t|author|year(?:par)?|title)?[ANP]*\\*?)((?:(?:\\([^\\)]*\\)){0,2}(?:\\[[^\\]]*\\]){0,2}\\{[\\w:.]*\\})*)(?:(\\[)[^\\]]*(\\]))?(?:(\\[)[^\\]]*(\\]))?(\\{)",
+        "captures": {
+          "1": {
+            "name": "keyword.control.cite.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.keyword.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#autocites-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.arguments.optional.begin.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.optional.end.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.arguments.optional.begin.latex"
+          },
+          "7": {
+            "name": "punctuation.definition.arguments.optional.end.latex"
+          },
+          "8": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.citation.latex",
+        "patterns": [
+          {
+            "match": "[\\w:.]+",
+            "name": "constant.other.reference.citation.latex"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)bibentry)(\\{)",
+        "captures": {
+          "1": {
+            "name": "keyword.control.cite.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.keyword.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.citation.latex",
+        "patterns": [
+          {
+            "match": "[\\w:.]+",
+            "name": "constant.other.reference.citation.latex"
+          }
+        ]
+      },
+      {
+        "begin": "((\\\\)(?:\\w*[r|R]ef\\*?))(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.control.ref.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.keyword.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.reference.label.latex",
+        "patterns": [
+          {
+            "match": "[a-zA-Z0-9\\.,:/*!^_-]",
+            "name": "constant.other.reference.label.latex"
+          }
+        ]
+      },
+      {
+        "include": "#definition-label"
+      },
+      {
+        "begin": "((\\\\)verb[\\*]?)\\s*((\\\\)scantokens)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "support.function.verb.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "support.function.verb.latex"
+          },
+          "4": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.begin.latex"
+          }
+        },
+        "contentName": "markup.raw.verb.latex",
+        "end": "(\\})",
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.definition.end.latex"
+          }
+        },
+        "name": "meta.function.verb.latex",
+        "patterns": [
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.verb.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "4": {
+            "name": "markup.raw.verb.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.verb.latex"
+          }
+        },
+        "match": "((\\\\)verb[\\*]?)\\s*((?<=\\s)\\S|[^a-zA-Z])(.*?)(\\3|$)",
+        "name": "meta.function.verb.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.verb.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "7": {
+            "name": "markup.raw.verb.latex"
+          },
+          "8": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "9": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "10": {
+            "name": "markup.raw.verb.latex"
+          },
+          "11": {
+            "name": "punctuation.definition.verb.latex"
+          }
+        },
+        "match": "((\\\\)(?:mint|mintinline))((?:\\[[^\\[]*?\\])?)(\\{)[a-zA-Z]*(\\})(?:(?:([^a-zA-Z\\{])(.*?)(\\6))|(?:(\\{)(.*?)(\\})))",
+        "name": "meta.function.verb.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "support.function.verb.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#optional-arg"
+              }
+            ]
+          },
+          "4": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "5": {
+            "name": "markup.raw.verb.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "7": {
+            "name": "punctuation.definition.verb.latex"
+          },
+          "8": {
+            "name": "markup.raw.verb.latex"
+          },
+          "9": {
+            "name": "punctuation.definition.verb.latex"
+          }
+        },
+        "match": "((\\\\)[a-z]+inline)((?:\\[[^\\[]*?\\])?)(?:(?:([^a-zA-Z\\{])(.*?)(\\4))|(?:(\\{)(.*?)(\\})))",
+        "name": "meta.function.verb.latex"
+      },
+      {
+        "match": "\\\\(?:newline|pagebreak|clearpage|linebreak|pause)(?:\\b)",
+        "name": "keyword.control.layout.latex"
+      },
+      {
+        "begin": "\\\\\\(",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.latex"
+          }
+        },
+        "end": "\\\\\\)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.latex"
+          }
+        },
+        "name": "meta.math.block.latex support.class.math.block.environment.latex",
+        "patterns": [
+          {
+            "include": "text.tex#math"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "\\$\\$",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.latex"
+          }
+        },
+        "end": "\\$\\$",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.latex"
+          }
+        },
+        "name": "meta.math.block.latex support.class.math.block.environment.latex",
+        "patterns": [
+          {
+            "match": "\\\\\\$",
+            "name": "constant.character.escape.latex"
+          },
+          {
+            "include": "text.tex#math"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "begin": "\\\\\\[",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.latex"
+          }
+        },
+        "end": "\\\\\\]",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.latex"
+          }
+        },
+        "name": "meta.math.block.latex support.class.math.block.environment.latex",
+        "patterns": [
+          {
+            "include": "text.tex#math"
+          },
+          {
+            "include": "$base"
+          }
+        ]
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "punctuation.definition.constant.latex"
+          }
+        },
+        "match": "(\\\\)(text(s(terling|ixoldstyle|urd|e(ction|venoldstyle|rvicemark))|yen|n(ineoldstyle|umero|aira)|c(ircledP|o(py(left|right)|lonmonetary)|urrency|e(nt(oldstyle)?|lsius))|t(hree(superior|oldstyle|quarters(emdash)?)|i(ldelow|mes)|w(o(superior|oldstyle)|elveudash)|rademark)|interrobang(down)?|zerooldstyle|o(hm|ne(superior|half|oldstyle|quarter)|penbullet|rd(feminine|masculine))|d(i(scount|ed|v(orced)?)|o(ng|wnarrow|llar(oldstyle)?)|egree|agger(dbl)?|blhyphen(char)?)|uparrow|p(ilcrow|e(so|r(t(housand|enthousand)|iodcentered))|aragraph|m)|e(stimated|ightoldstyle|uro)|quotes(traight(dblbase|base)|ingle)|f(iveoldstyle|ouroldstyle|lorin|ractionsolidus)|won|l(not|ira|e(ftarrow|af)|quill|angle|brackdbl)|a(s(cii(caron|dieresis|acute|grave|macron|breve)|teriskcentered)|cutedbl)|r(ightarrow|e(cipe|ferencemark|gistered)|quill|angle|brackdbl)|g(uarani|ravedbl)|m(ho|inus|u(sicalnote)?|arried)|b(igcircle|orn|ullet|lank|a(ht|rdbl)|rokenbar)))\\b",
+        "name": "constant.character.latex"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "punctuation.definition.column-specials.begin.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.column-specials.end.latex"
+          }
+        },
+        "match": "(?:<|>)(\\{)\\$(\\})",
+        "name": "meta.column-specials.latex"
+      },
+      {
+        "include": "text.tex"
+      }
+    ],
+    "repository": {
+      "optional-arg": {
+        "patterns": [
+          {
+            "captures": {
+              "1": {
+                "name": "punctuation.definition.optional.arguments.begin.latex"
+              },
+              "2": {
+                "name": "variable.parameter.function.latex"
+              },
+              "3": {
+                "name": "punctuation.definition.optional.arguments.end.latex"
+              }
+            },
+            "match": "(\\[)([^\\[]*?)(\\])",
+            "name": "meta.parameter.optional.latex"
+          }
+        ]
+      },
+      "autocites-arg": {
+        "patterns": [
+          {
+            "captures": {
+              "1": {
+                "name": "punctuation.definition.arguments.optional.begin.latex"
+              },
+              "2": {
+                "name": "punctuation.definition.arguments.optional.end.latex"
+              },
+              "3": {
+                "name": "punctuation.definition.arguments.optional.begin.latex"
+              },
+              "4": {
+                "name": "punctuation.definition.arguments.optional.end.latex"
+              },
+              "5": {
+                "name": "punctuation.definition.arguments.begin.latex"
+              },
+              "6": {
+                "name": "constant.other.reference.citation.latex"
+              },
+              "7": {
+                "name": "punctuation.definition.arguments.end.latex"
+              },
+              "8": {
+                "patterns": [
+                  {
+                    "include": "#autocites-arg"
+                  }
+                ]
+              }
+            },
+            "match": "(?:(\\()[^\\)]*(\\))){0,2}(?:(\\[)[^\\]]*(\\])){0,2}(\\{)([\\w:.]+)(\\})(.*)"
+          }
+        ]
+      },
+      "minted-env": {
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.arguments.optional.begin.latex"
+          },
+          "7": {
+            "name": "punctuation.definition.arguments.optional.end.latex"
+          },
+          "8": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "9": {
+            "name": "variable.parameter.function.latex"
+          },
+          "10": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "match": "((\\\\)(?:begin|end))(\\{)(lstlisting|minted|pyglist)(\\})(?:(\\[).*(\\]))?(?:(\\{)([a-z]*)(\\}))?"
+      },
+      "code-env": {
+        "captures": {
+          "1": {
+            "name": "support.function.be.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.function.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          },
+          "4": {
+            "name": "variable.parameter.function.latex"
+          },
+          "5": {
+            "name": "punctuation.definition.arguments.end.latex"
+          },
+          "6": {
+            "name": "punctuation.definition.arguments.optional.begin.latex"
+          },
+          "7": {
+            "name": "punctuation.definition.arguments.optional.end.latex"
+          }
+        },
+        "match": "(?:\\s*)((\\\\)(?:begin|end))(\\{)([a-z]*code(?:\\*)?|gnuplot|dot2tex|asy|sage[a-z]*)(\\})(?:(\\[).*(\\]))?"
+      },
+      "definition-label": {
+        "begin": "((\\\\)label)(\\{)",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.control.label.latex"
+          },
+          "2": {
+            "name": "punctuation.definition.keyword.latex"
+          },
+          "3": {
+            "name": "punctuation.definition.arguments.begin.latex"
+          }
+        },
+        "end": "\\}",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.arguments.end.latex"
+          }
+        },
+        "name": "meta.definition.label.latex",
+        "patterns": [
+          {
+            "match": "[a-zA-Z0-9\\.,:/*!^_-]",
+            "name": "variable.parameter.definition.label.latex"
+          }
+        ]
+      }
+    },
+    "scopeName": "text.tex.latex",
+    "uuid": "3BEEA00C-6B1D-11D9-B8AD-000D93589AF6"
+  }

--- a/vdmpp/syntaxes/latex.tmLanguage.json
+++ b/vdmpp/syntaxes/latex.tmLanguage.json
@@ -1,4 +1,5 @@
 {
+    "comment": "quote from https://github.com/James-Yu/LaTeX-Workshop/blob/master/syntax/LaTeX.tmLanguage.json",
     "fileTypes": [
       "tex"
     ],
@@ -6,16 +7,6 @@
     "keyEquivalent": "^~L",
     "name": "LaTeX",
     "patterns": [
-      {
-        "begin": "(\\\\begin\\{vdm_al\\})",
-        "contentName": "source.vdmpp",
-        "patterns": [
-            {
-            "include": "source.vdmpp"
-            }
-        ],
-        "end": "(\\\\end\\{vdm_al\\})"
-      },
       {
         "comment": "This scope identifies partially typed commands such as `\\tab`. We use this to trigger “Command Completion” only when it makes sense.",
         "match": "(?<=\\\\[\\w@]|\\\\[\\w@]{2}|\\\\[\\w@]{3}|\\\\[\\w@]{4}|\\\\[\\w@]{5}|\\\\[\\w@]{6})\\s",
@@ -930,6 +921,33 @@
         },
         "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?",
         "name": "meta.function.environment.latex.mpost"
+      },
+      {
+        "begin": "(?:\\s*)((\\\\)begin)(\\{)(vdm_al[*]?)(\\})",
+        "contentName": "source.vdmpp",
+        "captures": {
+            "1": {
+              "name": "support.function.be.latex"
+            },
+            "2": {
+              "name": "punctuation.definition.function.latex"
+            },
+            "3": {
+              "name": "punctuation.definition.arguments.begin.latex"
+            },
+            "4": {
+              "name": "variable.parameter.function.latex"
+            },
+            "5": {
+              "name": "punctuation.definition.arguments.end.latex"
+            }
+        },
+        "patterns":[
+            {
+                "include": "source.vdmpp"
+            }
+        ],
+        "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?"
       },
       {
         "begin": "(?:\\s*)((\\\\)begin)(\\{)(\\w+[*]?)(\\})",


### PR DESCRIPTION
This pull request is an example of one.

It can highlight the VDM in LaTeX in the following ways
- Prepare and configure a language file of LaTeX.
- Define the area surrounded by `begin{vdm_al}` and `end{vdm_al}` as VDM.

Lines 925-951 of latex.tmLanguage.json
```json
      {
        "begin": "(?:\\s*)((\\\\)begin)(\\{)(vdm_al[*]?)(\\})",
        "contentName": "source.vdmpp",
        "captures": {
            "1": {
              "name": "support.function.be.latex"
            },
            "2": {
              "name": "punctuation.definition.function.latex"
            },
            "3": {
              "name": "punctuation.definition.arguments.begin.latex"
            },
            "4": {
              "name": "variable.parameter.function.latex"
            },
            "5": {
              "name": "punctuation.definition.arguments.end.latex"
            }
        },
        "patterns":[
            {
                "include": "source.vdmpp"
            }
        ],
        "end": "((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?"
      },
```

But the file extension must be tex. Can't \*.vdm.

<img width="424" alt="スクリーンショット 2020-11-29 20 49 27" src="https://user-images.githubusercontent.com/20027695/100541109-015f6400-3285-11eb-8c58-b0e41e2b8107.png">
